### PR TITLE
fixes: link in talk section and number of talks displayed in homepage 

### DIFF
--- a/components/section/homepage/Talks.vue
+++ b/components/section/homepage/Talks.vue
@@ -34,7 +34,8 @@ const randomizeTalks = computed(() => {
 
 <template>
   <section class="p-section flex flex-col items-center
-  justify-center bg-bdxio-grey-100 bg-bdxio-cream-base">
+  justify-center bg-bdxio-grey-100 bg-bdxio-cream-base"
+  >
     <Heading
       level="2"
       class="text-center"

--- a/components/section/homepage/Talks.vue
+++ b/components/section/homepage/Talks.vue
@@ -28,14 +28,13 @@ const randomizeTalks = computed(() => {
     }
     return acc;
   }, []);
-  return firstTalkPerCategory.splice(NUMBER_OF_TALKS_TO_SHOW);
+  return firstTalkPerCategory.splice(0, NUMBER_OF_TALKS_TO_SHOW);
 });
 </script>
 
 <template>
   <section class="p-section flex flex-col items-center
-  justify-center bg-bdxio-grey-100 bg-bdxio-cream-base"
-  >
+  justify-center bg-bdxio-grey-100 bg-bdxio-cream-base">
     <Heading
       level="2"
       class="text-center"

--- a/pages/talks/[id].vue
+++ b/pages/talks/[id].vue
@@ -29,13 +29,14 @@ if (!talk.value || talk.value?.edition?.year !== EDITION || talk.value?.type ===
       :key="speaker.id"
       :speaker="speaker"
     />
-    <LinkPrimaryNuxt
+    <LinkSecondary
       v-if="$featureFlags.pages.schedule.show"
       color="light"
       to="/schedule"
+      type="link"
       class="block mt-5 mx-auto mb-0"
     >
       Voir le programme
-    </LinkPrimaryNuxt>
+    </LinkSecondary>
   </main>
 </template>


### PR DESCRIPTION
section | before | after 
-- | -- | -- 
homepage | <img width="1318" height="688" alt="image" src="https://github.com/user-attachments/assets/3da6d6de-c6dd-4139-8e1d-b9e81aa64731" />  | <img width="1316" height="692" alt="image" src="https://github.com/user-attachments/assets/60e70647-c9ce-4c9a-8568-e40de4640f5e" />
talk details | <img width="1319" height="896" alt="image" src="https://github.com/user-attachments/assets/3b9264c3-e351-47e9-8bea-56db2a8856f5" /> | <img width="1046" height="895" alt="image" src="https://github.com/user-attachments/assets/d692e532-f009-4f34-a24f-59d8b3c3c556" /> 