### PR TITLE
feat(homepage): add section for last year's sponsors

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ASSOCIATION_NAME } from "~/services/constants";
+import { ASSOCIATION_NAME, PREVIOUS_EDITION } from "~/services/constants";
 import type { Edition } from "@bdxio/bdxio.types";
 
 const { $featureFlags } = useNuxtApp();
@@ -36,6 +36,10 @@ const editionData = data.value[0];
     <SectionHomepageFigures v-if="$featureFlags.pages.homepage.sections.figures" />
     <SectionHomepageTalks v-if="$featureFlags.pages.homepage.sections.talks" />
     <SectionHomepageTheme v-if="$featureFlags.pages.homepage.sections.theme" />
+    <SectionSponsors
+      v-if="$featureFlags.pages.homepage.sections.lastYearSponsors"
+      :edition="PREVIOUS_EDITION"
+    />
     <SectionHomepageMateriel v-if="$featureFlags.pages.homepage.sections.materiel" />
     <SectionHomepageCategories v-if="$featureFlags.pages.homepage.sections.categories" />
     <div

--- a/plugins/featureFlags/index.ts
+++ b/plugins/featureFlags/index.ts
@@ -15,6 +15,7 @@ export default defineNuxtPlugin(() => ({
             dDay: false,
             categories: true,
             sponsor: false,
+            lastYearSponsors: true,
             participant: false,
             talks: false,
           },


### PR DESCRIPTION
Add a section + associated feature flag to display last year's sponsors on the homepage. 

Before | After 
-- | -- 
<img width="2632" height="6110" alt="image" src="https://github.com/user-attachments/assets/61d1db54-d3c5-4d5d-ba4a-2c213646be20" /> | <img width="2632" height="9070" alt="image" src="https://github.com/user-attachments/assets/1b42b2c1-8796-479c-841d-8db33f910099" />

